### PR TITLE
Allow the user to initialize the browser  env with other ways

### DIFF
--- a/src/init_browser.ts
+++ b/src/init_browser.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "path";
 import { Environment } from "./environment.js";
 import { browserManager } from "./browser_manager.js";
 import { TestContext } from "./test_context.js";
@@ -9,7 +10,11 @@ import { Browser } from "./browser_manager.js";
 // let environment = null;
 
 // init browser create context and page, if context and page are not null
-const getContext = async function (environment: Environment | null, headless = false, logger?: null) {
+const getContext = async function (
+  environment: Environment | null,
+  headless = false,
+  logger?: null
+) {
   if (environment === null) {
     environment = initEnvironment();
   }
@@ -56,7 +61,26 @@ const initEnvironment = function () {
   // if (environment === null) {
   const environment = new Environment();
   try {
-    const data = fs.readFileSync("env.json", "utf8");
+    let envFile = "";
+    const envArgVal = checkForEnvArg();
+    if (envArgVal) {
+      envFile = envArgVal;
+    } else if (process.env.BLINQ_ENV) {
+      envFile = process.env.BLINQ_ENV;
+    } else if (fs.existsSync(path.join(process.cwd(), "env.json"))) {
+      envFile = path.join(process.cwd(), "env.json");
+    } else {
+      let files = fs.readdirSync(path.join(process.cwd(), "environments"));
+      for (let i = 0; i < files.length; i++) {
+        let file = files[i];
+        if (file.endsWith(".json")) {
+          envFile = path.join(process.cwd(), "environments", file);
+          break;
+        }
+      }
+    }
+    // console.log("envFile: ", envFile);
+    const data = fs.readFileSync(envFile, "utf8");
     //console.log("data", data);
     const envObject = JSON.parse(data);
     //console.log("envObject", envObject);
@@ -69,5 +93,15 @@ const initEnvironment = function () {
   // }
   return environment;
 };
-
+const checkForEnvArg = function () {
+  for (let arg of process.argv.slice(2)) {
+    if (arg.startsWith("--")) {
+      const [key, value] = arg.split("=");
+      if (key.slice(2) === "env") {
+        return value;
+      }
+    }
+  }
+  return null;
+};
 export { getContext, closeBrowser };


### PR DESCRIPTION
Changed the `init_browser.ts` to allow the user to pass env file by either through arg or through process environment   .