### PR TITLE
fix: escape ' ,  " , > chars when converting to regex

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -74,8 +74,35 @@ function _convertToRegexQuery(text: string, isRegex: boolean, fullMatch: boolean
   }
   return query + pattern + queryEnd;
 }
-function escapeRegex(s: string) {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+function escapeRegex(str: string) {
+  // Special regex characters that need to be escaped
+  const specialChars = [
+    "/",
+    ".",
+    "*",
+    "+",
+    "?",
+    "^",
+    "$",
+    "(",
+    ")",
+    "[",
+    "]",
+    "{",
+    "}",
+    "|",
+    "\\",
+    "-",
+    "'",
+    '"',
+    ">", // added to avoid confusion with pw selectorsxw
+  ];
+
+  // Create a regex that will match all special characters
+  const escapeRegex = new RegExp(specialChars.map((char) => `\\${char}`).join("|"), "g");
+
+  // Escape special characters by prefixing them with a backslash
+  return str.replace(escapeRegex, "\\$&");
 }
 function _findKey() {
   if (process.env.PROJECT_ID) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -99,10 +99,10 @@ function escapeRegex(str: string) {
   ];
 
   // Create a regex that will match all special characters
-  const escapeRegex = new RegExp(specialChars.map((char) => `\\${char}`).join("|"), "g");
+  const escapedRegex = new RegExp(specialChars.map((char) => `\\${char}`).join("|"), "g");
 
   // Escape special characters by prefixing them with a backslash
-  return str.replace(escapeRegex, "\\$&");
+  return str.replace(escapedRegex, "\\$&");
 }
 function _findKey() {
   if (process.env.PROJECT_ID) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved regex escaping utility function with more comprehensive special character handling
	- Updated function parameter name for better readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->