### PR TITLE
fix: use data-blinq-id to stablize locator

### DIFF
--- a/src/stable_browser.ts
+++ b/src/stable_browser.ts
@@ -619,8 +619,15 @@ class StableBrowser {
         info.log += "searching for locator " + j + ":" + JSON.stringify(selector) + "\n";
       }
       let element = await this._locate_internal(selectors, info, _params, timeout, allowDisabled);
+
       if (!element.rerun) {
-        return element;
+        const randomToken = Math.random().toString(36).substring(7);
+        element.evaluate((el, randomToken) => {
+          el.setAttribute("data-blinq-id-" + randomToken, "");
+        }, randomToken);
+        const page = element.page();
+        const newSelector = page.locator("[data-blinq-id-" + randomToken + "]");
+        return newSelector;
       }
     }
     throw new Error("unable to locate element " + JSON.stringify(selectors));
@@ -1465,7 +1472,8 @@ class StableBrowser {
         this._highlightElements(element)
           .then(async () => {
             await new Promise((resolve) => setTimeout(resolve, 1000));
-            this._unhighlightElements(element).then(() => {}
+            this._unhighlightElements(element).then(
+              () => {}
               // console.log(`Unhighlighting vrtr in recorder is successful`)
             );
           })
@@ -2138,8 +2146,7 @@ class StableBrowser {
               //}, 2000);
             }
           })
-          .then(() => {
-          })
+          .then(() => {})
           .catch((e) => {
             // ignore
             // console.error(`Could not highlight node : ${e}`);
@@ -2176,8 +2183,7 @@ class StableBrowser {
             },
             [css]
           )
-          .then(() => {
-          })
+          .then(() => {})
           .catch((e) => {
             // ignore
             // console.error(`Could not highlight css: ${e}`);
@@ -2201,11 +2207,10 @@ class StableBrowser {
                 node.style.outline = "";
               } else {
                 node.style.outline = node.__previousOutline;
-              } 
+              }
             }
           })
-          .then(() => {
-          })
+          .then(() => {})
           .catch((e) => {
             // console.log(`Error while unhighlighting node ${JSON.stringify(scope)}: ${e}`);
           });
@@ -2228,8 +2233,7 @@ class StableBrowser {
               }
             }
           })
-          .then(() => {
-          })
+          .then(() => {})
           .catch((e) => {
             // console.error(`Error while unhighlighting element in css: ${e}`);
           });
@@ -2404,9 +2408,10 @@ class StableBrowser {
                 .then(async () => {
                   // console.log(`Unhighlighted frame dataAttribute successfully`);
                 })
-                .catch((e) => {}
+                .catch(
+                  (e) => {}
                   //  console.error(e)
-              );
+                );
             });
           }
           const element = await frame.locator(dataAttribute).first();
@@ -2561,7 +2566,8 @@ class StableBrowser {
                 this._highlightElements(frame, dataAttribute)
                   .then(async () => {
                     await new Promise((resolve) => setTimeout(resolve, 1000));
-                    this._unhighlightElements(frame, dataAttribute).then(() => {}
+                    this._unhighlightElements(frame, dataAttribute).then(
+                      () => {}
                       // console.log(`Unhighlighting vrtr in recorder is successful`)
                     );
                   })


### PR DESCRIPTION
proposed logic:
1. locate the element
2. before performing any actions on the element add a data-blinq-id attibute
3. generate a new locator using data-blinq-id attribute alone
4. use this new locator to perform action

this will make our locators stable, and prevent failures in cases where element properties change once you start interacting with it, 
for ex: 
in clickType event, we first clear the input then click and then fill
but after clearing input the placeholder changed, so it was no longer able to find the element when clicking



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an enhanced mechanism to uniquely identify elements during interactions.

- **Refactor**
  - Improved asynchronous handling for dynamic element operations, ensuring smoother interactions and more reliable text and visual updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->