### PR TITLE
fix: do not perform navigate when connecting via cdp

### DIFF
--- a/src/init_browser.ts
+++ b/src/init_browser.ts
@@ -124,6 +124,11 @@ const getContext = async function (
   context.reportFolder = reportFolder;
   context.initScripts = initScripts;
 
+  if (process.env.CDP_CONNECT_URL) {
+    // settin it to true will not navigate
+    context.navigate = true;
+  }
+
   if (createStable) {
     context.stable = new StableBrowser(context.browser!, context.page!, logger, context, world);
   } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a configuration option that adjusts browser navigation behavior. When the specific setting is applied, navigation can be automatically disabled, allowing for more controlled browser context initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->