### PR TITLE
Fix: unescaping just before convertToRegex and escaping in convertToR…

### DIFF
--- a/src/stable_browser.ts
+++ b/src/stable_browser.ts
@@ -2455,7 +2455,7 @@ class StableBrowser {
     };
 
     if (testForRegex(text)) {
-      text = text.replace(/"/g, '\\"');
+      text = text.replace(/\\"/g, '"');
     }
 
     const timeout = this._getFindElementTimeout(options);
@@ -2547,6 +2547,10 @@ class StableBrowser {
       operation: "verifyTextNotExistInPage",
       log: "***** verify text " + text + " does not exist in page *****\n",
     };
+
+    if (testForRegex(text)) {
+      text = text.replace(/\\"/g, '"');
+    }
 
     const timeout = this._getFindElementTimeout(options);
     await new Promise((resolve) => setTimeout(resolve, 2000));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,6 +69,7 @@ function _convertToRegexQuery(text: string, isRegex: boolean, fullMatch: boolean
     if (match) {
       try {
         const regex = new RegExp(text.substring(1, text.lastIndexOf("/")), text.match(regexEndPattern)![1]);
+        text = text.replace(/"/g, '\\"');
         return "internal:text=" + text;
       } catch {
         // not regex


### PR DESCRIPTION
…egex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved text handling to ensure that double quotes display and process correctly during regex operations.
  - Enhanced escaping of quoted text to provide more reliable formatting and consistency in text processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->